### PR TITLE
add mbed-os.lib file

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8


### PR DESCRIPTION
Mbed Studio can recognize as a mbed program.
If Mbed Studio could not recognize as a program, activating(selecting) this program is not available. 

and this will make Mbed Studio to automatically download mbed-os library.